### PR TITLE
Make the release workflow run only when a tag is pushed

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - v[0-9]+.**
-    branches:
-      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently it runs when a tag is pushed, but also every time something is pushed to main.