### PR TITLE
Collect IBM-Cloud VNI objects

### DIFF
--- a/pkg/ibm/datamodel/data_model.go
+++ b/pkg/ibm/datamodel/data_model.go
@@ -251,6 +251,33 @@ func NewInstance(instance *vpcv1.Instance, networkInterfaces []vpcv1.NetworkInte
 
 func (res *Instance) GetCRN() *string { return res.CRN }
 
+// Virtual Network Interface object
+type VirtualNI struct {
+	vpcv1.VirtualNetworkInterface
+	BaseTaggedResource
+}
+
+func NewVirtualNI(vni *vpcv1.VirtualNetworkInterface) *VirtualNI {
+	return &VirtualNI{VirtualNetworkInterface: *vni}
+}
+
+func (res *VirtualNI) GetCRN() *string { return res.CRN }
+
+func (res *VirtualNI) UnmarshalJSON(data []byte) error {
+	asMap, err := jsonToMap(data)
+	if err != nil {
+		return err
+	}
+	asObj := &vpcv1.VirtualNetworkInterface{}
+	err = vpcv1.UnmarshalVirtualNetworkInterface(asMap, &asObj)
+	if err != nil {
+		return err
+	}
+	res.VirtualNetworkInterface = *asObj
+
+	return json.Unmarshal(data, &res.BaseTaggedResource)
+}
+
 // RoutingTable configuration object (not taggable)
 type RoutingTable struct {
 	vpcv1.RoutingTable

--- a/pkg/ibm/datamodel/resources_container_model.go
+++ b/pkg/ibm/datamodel/resources_container_model.go
@@ -25,6 +25,7 @@ type ResourcesContainerModel struct {
 	SecurityGroupList     []*SecurityGroup     `json:"security_groups"`
 	EndpointGWList        []*EndpointGateway   `json:"endpoint_gateways"`
 	InstanceList          []*Instance          `json:"instances"`
+	VirtualNIList         []*VirtualNI         `json:"virtual_nis"`
 	RoutingTableList      []*RoutingTable      `json:"routing_tables"`
 	LBList                []*LoadBalancer      `json:"load_balancers"`
 	TransitConnectionList []*TransitConnection `json:"transit_connections"`
@@ -43,6 +44,7 @@ func NewResourcesContainerModel() *ResourcesContainerModel {
 		SecurityGroupList:     []*SecurityGroup{},
 		EndpointGWList:        []*EndpointGateway{},
 		InstanceList:          []*Instance{},
+		VirtualNIList:         []*VirtualNI{},
 		RoutingTableList:      []*RoutingTable{},
 		LBList:                []*LoadBalancer{},
 		TransitConnectionList: []*TransitConnection{},
@@ -62,6 +64,7 @@ func (resources *ResourcesContainerModel) PrintStats() {
 	fmt.Printf("Found %d security groups\n", len(resources.SecurityGroupList))
 	fmt.Printf("Found %d endpoint gateways (VPEs)\n", len(resources.EndpointGWList))
 	fmt.Printf("Found %d instances\n", len(resources.InstanceList))
+	fmt.Printf("Found %d virtual network interfaces\n", len(resources.VirtualNIList))
 	fmt.Printf("Found %d routing tables\n", len(resources.RoutingTableList))
 	fmt.Printf("Found %d load balancers\n", len(resources.LBList))
 	fmt.Printf("Found %d transit connections\n", len(resources.TransitConnectionList))

--- a/pkg/ibm/datamodel/test/data/demo-with-instances-config.json
+++ b/pkg/ibm/datamodel/test/data/demo-with-instances-config.json
@@ -3142,6 +3142,7 @@
             "tags": []
         }
     ],
+    "virtual_nis": [],
     "routing_tables": [
         {
             "accept_routes_from": [

--- a/pkg/ibm/datamodel/test/data/experiments_env.json
+++ b/pkg/ibm/datamodel/test/data/experiments_env.json
@@ -2286,6 +2286,76 @@
             "tags": []
         }
     ],
+    "virtual_nis": [
+        {
+            "allow_ip_spoofing": false,
+            "auto_delete": true,
+            "created_at": "2024-06-17T11:44:17.000Z",
+            "crn": "crn:4879",
+            "enable_infrastructure_nat": true,
+            "href": "href:80987",
+            "id": "id:8888",
+            "ips": [
+                {
+                    "address": "10.240.64.4",
+                    "href": "href:98765",
+                    "id": "id:87654",
+                    "name": "rip875",
+                    "resource_type": "subnet_reserved_ip"
+                }
+            ],
+            "lifecycle_state": "stable",
+            "mac_address": "99:88:77:66:55:DD",
+            "name": "vni456",
+            "primary_ip": {
+                "address": "10.240.64.4",
+                "href": "href:98765",
+                "id": "id:87654",
+                "name": "rip875",
+                "resource_type": "subnet_reserved_ip"
+            },
+            "protocol_state_filtering_mode": "auto",
+            "resource_group": {
+                "href": "href:15",
+                "id": "id:16",
+                "name": "anonymous"
+            },
+            "resource_type": "virtual_network_interface",
+            "security_groups": [
+                {
+                    "crn": "crn:12",
+                    "href": "href:13",
+                    "id": "id:14",
+                    "name": "suitcase-singular-profile-professed"
+                }
+            ],
+            "subnet": {
+                "crn": "crn:93",
+                "href": "href:94",
+                "id": "id:95",
+                "name": "subnet21-ky",
+                "resource_type": "subnet"
+            },
+            "target": {
+                "href": "href:888866",
+                "id": "id:999977",
+                "name": "eth0",
+                "resource_type": "instance_network_attachment"
+            },
+            "vpc": {
+                "crn": "crn:17",
+                "href": "href:18",
+                "id": "id:19",
+                "name": "test-vpc2-ky",
+                "resource_type": "vpc"
+            },
+            "zone": {
+                "href": "href:5",
+                "name": "us-south-2"
+            },
+            "tags": []
+        }
+    ],
     "routing_tables": [
         {
             "accept_routes_from": [

--- a/pkg/ibm/datamodel/test/data/iks-on-goldeneye-vpc-config.json
+++ b/pkg/ibm/datamodel/test/data/iks-on-goldeneye-vpc-config.json
@@ -3157,6 +3157,7 @@
         }
     ],
     "instances": [],
+    "virtual_nis": [],
     "routing_tables": [
         {
             "accept_routes_from": [

--- a/pkg/ibm/datamodel/test/data/transit-gateways.json
+++ b/pkg/ibm/datamodel/test/data/transit-gateways.json
@@ -1510,6 +1510,7 @@
             "tags": []
         }
     ],
+    "virtual_nis": [],
     "routing_tables": [
         {
             "accept_routes_from": [

--- a/pkg/ibm/resources_container.go
+++ b/pkg/ibm/resources_container.go
@@ -153,6 +153,13 @@ func (resources *ResourcesContainer) collectTags() error {
 		}
 	}
 
+	for i := range resources.VirtualNIList {
+		err := tagsCollector.setResourceTags(resources.VirtualNIList[i])
+		if err != nil {
+			return err
+		}
+	}
+
 	for i := range resources.LBList {
 		err := tagsCollector.setResourceTags(resources.LBList[i])
 		if err != nil {
@@ -236,6 +243,7 @@ func (resources *ResourcesContainer) CollectResourcesFromAPI() error {
 	return nil
 }
 
+//nolint:funlen // function is long because there are many types of resources we collect
 func (resources *ResourcesContainer) collectRegionalResources(region, apiKey string) error {
 	// check if region is valid
 	if _, ok := vpcRegionURLs[region]; !ok {
@@ -315,6 +323,12 @@ func (resources *ResourcesContainer) collectRegionalResources(region, apiKey str
 		return err
 	}
 	resources.InstanceList = append(resources.InstanceList, insts...)
+
+	vnis, err := getVirtualNIs(vpcService, resources.resourceGroupID)
+	if err != nil {
+		return err
+	}
+	resources.VirtualNIList = append(resources.VirtualNIList, vnis...)
 
 	// Routing Tables
 	rts, err := getRoutingTables(vpcService, vpcs)


### PR DESCRIPTION
Fixes #311 

We will have a new `virtual_nis` collection in the data model.
No change to the `Instance` struct, as there is no API call to list all VNIs of a VSI. It's therefore better to implement this association in the analyzer. (There is an API call to list all Network-Attachment of a VSI, but we already have these).

Also, a small refactoring to avoid code duplication